### PR TITLE
JupyterSplashTikz now uses png

### DIFF
--- a/gap/JupyterUtil.gi
+++ b/gap/JupyterUtil.gi
@@ -89,7 +89,7 @@ function(tikz)
 
     else 
         ltx := Concatenation( "pdf2svg ", Concatenation( fn, ".pdf" ), " ",
-                    svgfile);
+                    svgfile, "; base64 ", svgfile," >> ", b64file );
     fi;
     Exec( ltx );
     if not( IsExistingFile( svgfile ) ) then
@@ -97,27 +97,14 @@ function(tikz)
                             data := "No svg was created; pdf2svg is installed in your system?", metadata := rec());
         return JupyterRenderable(tojupyter.data, tojupyter.metadata);
     fi;
-    if ARCH_IS_MAC_OS_X() then 
-        stream := InputTextFile( b64file );
-        if stream <> fail then
-            svgdata := ReadLine( stream );
-            CloseStream( stream );
-        else
-            tojupyter := rec( json := true, name := "stdout",
-                                data := Concatenation( "Unable to render ", tikz ), metadata := rec() );
-            return JupyterRenderable(tojupyter.data, tojupyter.metadata);
-        fi;
+    stream := InputTextFile( b64file );
+    if stream <> fail then
+        svgdata := ReadAll( stream );
+        CloseStream( stream );
     else
-        stream := InputTextFile( svgfile );
-        if stream <> fail then
-            svgdata := ReadAll( stream );
-            svgdata:= SubstitutionSublist(Base64String(svgdata),"\n","");
-            CloseStream( stream );
-        else
-            tojupyter := rec( json := true, name := "stdout",
-                                data := Concatenation( "Unable to render ", tikz ), metadata := rec() );
-            return JupyterRenderable(tojupyter.data, tojupyter.metadata);
-        fi;
+        tojupyter := rec( json := true, name := "stdout",
+                            data := Concatenation( "Unable to render ", tikz ), metadata := rec() );
+        return JupyterRenderable(tojupyter.data, tojupyter.metadata);
     fi;
 
     img:=Concatenation("<img src='data:image/svg+xml;base64,", svgdata,"'>");

--- a/gap/JupyterUtil.gi
+++ b/gap/JupyterUtil.gi
@@ -45,16 +45,25 @@ end);
 # To show TikZ in a GAP jupyter notebook
 BindGlobal("JupyterSplashTikZ",
 function(tikz)
-    local tmpdir, fn, header, ltx, svgfile, stream, svgdata, tojupyter, b64file, img;
+    local tmpdir, fn, header, ltx, svgfile, stream, svgdata, tojupyter, b64file, hasbp, img;
+
+    hasbp:=PositionSublist(tikz,"begin{tikzpicture}")<>fail;
 
     header:=Concatenation( "\\documentclass[crop,tikz]{standalone}\n",
                     "\\usepackage{pgfplots}",
                     "\\makeatletter\n",
                     "\\batchmode\n",
                     "\\nonstopmode\n",
-                    "\\begin{document}");
+                    "\\begin{document}\n");
+    if not(hasbp) then 
+        Concatenation(header, "\\begin{tikzpicture}\n");
+    fi;
     header:=Concatenation(header, tikz);
-    header:=Concatenation(header,"\\end{document}");
+    if hasbp then 
+        header:=Concatenation(header,"\\end{document}");    
+    else
+        header:=Concatenation(header,"\\end{tikzpicture}\n\\end{document}");
+    fi;
 
     tmpdir := DirectoryTemporary();
     fn := Filename( tmpdir, "svg_get" );

--- a/gap/JupyterUtil.gi
+++ b/gap/JupyterUtil.gi
@@ -73,11 +73,15 @@ function(tikz)
         svgfile := Concatenation( fn, ".svg" );
         b64file := Concatenation( fn, ".b64" );
         ltx := Concatenation( "pdf2svg ", Concatenation( fn, ".pdf" ), " ",
-                       svgfile, "; base64 -i ", svgfile," -o ", b64file );
+                       svgfile, "; base64 -i ", svgfile," >> ", b64file );
         Exec( ltx );
-        if not( IsExistingFile( b64file ) ) then
+        if not( IsExistingFile( svgfile ) ) then
             tojupyter := rec( json := true, name := "stdout",
-                              data := "No svg was created; pdf2svg is installed in your system? base64 missing?" );
+                              data := "No svg was created; pdf2svg is installed in your system?", metadata := rec());
+            return JupyterRenderable(tojupyter.data, tojupyter.metadata);
+        elif not( IsExistingFile( b64file ) ) then
+            tojupyter := rec( json := true, name := "stdout",
+                              data := "No svg was created; base64 is installed in your system?", metadata := rec());
             return JupyterRenderable(tojupyter.data, tojupyter.metadata);
         else
             stream := InputTextFile( b64file );


### PR DESCRIPTION
Use png to display TikZ
Addeed documentation for `JupyterSplasDot` and `JupyterSplashTikZ`.
Two demo notebooks added: one for dot and the other for TikZ.